### PR TITLE
Indicate required node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,5 +120,8 @@
         "statements": 96,
         "functions": 95,
         "branches": 85
+    },
+    "engines": {
+      "node": ">=14"
     }
 }


### PR DESCRIPTION
Since the code uses optional chaining it requires node >=14 to run (https://node.green/#ES2020-features-optional-chaining-operator-----). This should be indicated in the package json.