### PR TITLE
Add `nopeer` option for ignoring peerDependencies. Add typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,6 @@ scanning ./yui-lint
 
 ## How Licenses are Found
 
-We walk through the `node_modules` directory with the [`read-installed`](https://www.npmjs.org/package/read-installed) module. Once we gathered a list of modules we walk through them and look at all of their `package.json`'s, We try to identify the license with the [`spdx`](https://www.npmjs.com/package/spdx) module to see if it has a valid SPDX license attached. If that fails, we then look into the module for the following files: `LICENSE`, `LICENCE`, `COPYING`, & `README`.
+We walk through the `node_modules` directory with the [`read-installed-packages`](https://www.npmjs.org/package/read-installed-packages) module. Once we gathered a list of modules we walk through them and look at all of their `package.json`'s, We try to identify the license with the [`spdx`](https://www.npmjs.com/package/spdx) module to see if it has a valid SPDX license attached. If that fails, we then look into the module for the following files: `LICENSE`, `LICENCE`, `COPYING`, & `README`.
 
 If one of the those files are found (in that order) we will attempt to parse the license data from it with a list of known license texts. This will be shown with the `*` next to the name of the license to show that we "guessed" at it.

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,173 @@
+/**
+ * Options struct for the init() function
+ */
+ export interface InitOpts {
+    /**
+     * Path to start checking dependencies from
+     */
+    start: string;
+    /**
+     * Only show production dependencies
+     */
+    production?: boolean | undefined;
+    /**
+     * Only show development dependencies
+     */
+    development?: boolean | undefined;
+    /**
+     * Report guessed licenses as unknown licenses
+     */
+    unknown?: boolean | undefined;
+    /**
+     * Only list packages with unknown or guessed licenses
+     */
+    onlyunknown?: boolean | undefined;
+    /**
+     * Output in json format
+     */
+    json?: boolean | undefined;
+    /**
+     * Output in csv format
+     */
+    csv?: boolean | undefined;
+    /**
+     * Prefix column for component in csv format.
+     */
+    csvComponentPrefix?: string | undefined;
+    /**
+     * Write the data to a specific file.
+     */
+    out?: string | undefined;
+    /**
+     * To add a custom Format file in JSON
+     */
+    customPath?: string | ModuleInfo | undefined;
+    /**
+     * Exclude modules which licenses are in the comma-separated list from the output
+     */
+    exclude?: string[] | undefined;
+    /**
+     * Output the location of the license files as relative paths
+     */
+    relativeLicensePath?: boolean | undefined;
+    /**
+     * Output a summary of the license usage
+     */
+    summary?: boolean | undefined;
+    /**
+     * Fail (exit with code 1) on the first occurrence of the licenses of the semicolon-separated list
+     */
+    failOn?: string | undefined;
+    /**
+     * Fail (exit with code 1) on the first occurrence of the licenses not in the semicolon-separated list
+     */
+    onlyAllow?: string | undefined;
+    /**
+     * Restrict output to the packages (package@version) in the semicolon-separated list
+     */
+    packages?: string | undefined;
+    /**
+     * Restrict output to the packages (package@version) not in the semicolon-separated list
+     */
+    excludePackages?: string | undefined;
+    /**
+     * Restrict output to not include any package marked as private
+     */
+    excludePrivatePackages?: boolean | undefined;
+    /**
+     * Look for direct dependencies only
+     */
+    direct?: boolean | undefined;
+    /**
+     * Colorize output
+     */
+    color?: boolean | undefined;
+    /**
+     * Specify the columns for CSV format
+     * or add the specified items for JSON format
+     */
+    customFormat?: Record<string, any> | undefined;
+    /**
+     * Ignore peerDependencies
+     */
+    nopeer?: boolean;
+}
+
+/**
+ * Information about one dependency
+ */
+export interface ModuleInfo {
+    /**
+     * Module name
+     */
+    name?: string | undefined;
+    /**
+     * Module version
+     */
+    version?: string | undefined;
+    /**
+     * Module description
+     */
+    description?: string | undefined;
+    /**
+     * Repository URL
+     */
+    repository?: string | undefined;
+    /**
+     * Publisher name
+     */
+    publisher?: string | undefined;
+    /**
+     * Publisher e-mail
+     */
+    email?: string | undefined;
+    /**
+     * Publisher URL
+     */
+    url?: string | undefined;
+    /**
+     * Array of licenses
+     */
+    licenses?: string | string[] | undefined;
+    /**
+     * Path to license file, if available
+     */
+    licenseFile?: string | undefined;
+    /**
+     * Contents of the license
+     */
+    licenseText?: string | undefined;
+    /**
+     * Whether the license is modified
+     */
+    licenseModified?: string | undefined;
+    /**
+     * Private module
+     */
+    private?: boolean | undefined;
+    /**
+     * Path to module
+     */
+    path?: string | undefined;
+    /**
+     * Copyright statements
+     */
+    copyright?: string | undefined;
+    /**
+     * Path of NOTICE file
+     */
+    noticeFile?: string | undefined;
+}
+
+export interface ModuleInfos {
+    [packageName: string]: ModuleInfo;
+}
+
+/**
+ * Run the license check
+ * @param opts specifies the path to the module to check dependencies of
+ */
+export function init(
+    opts: InitOpts,
+    callback: (err: Error, ret: ModuleInfos) => void
+): void;

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,7 @@ const getLicenseTitle = require('./getLicenseTitle');
 const licenseFiles = require('./license-files');
 const mkdirp = require('mkdirp');
 const path = require('path');
-const read = require('read-installed');
+const read = require('read-installed-packages');
 const spdxCorrect = require('spdx-correct');
 const spdxSatisfies = require('spdx-satisfies');
 const treeify = require('treeify');
@@ -290,6 +290,7 @@ exports.init = function init(args, callback) {
 
     const opts = {
         depth: args.direct,
+        nopeer: args.nopeer,
         dev: true,
         log: debugLog,
     };

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
         "debug": "^4.3.2",
         "mkdirp": "^1.0.4",
         "nopt": "^5.0.0",
-        "read-installed": "~4.0.3",
+        "read-installed-packages": "^1.0.0",
         "semver": "^7.3.5",
         "spdx-correct": "^3.1.1",
         "spdx-expression-parse": "^3.0.1",
@@ -93,6 +93,7 @@
         "oss"
     ],
     "main": "./lib/index.js",
+    "types": "./lib/index.d.ts",
     "bin": {
         "license-checker-rseidelsohn": "./bin/license-checker-rseidelsohn"
     },


### PR DESCRIPTION
Currently `peerDependencies` are not installed automatically. This option is needed for avoiding to have package B in output if it is a devDependency and peerDependency of dependency A (if we no need to check devDependencies):

```
Project
|
| - A (dependency)
|   | - B (peerDependency)
|
| - B (devDependency) 
```

---

Also add typings. Fixes #21