### PR TITLE
Adjust license file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,18 @@ You could see something like this:
    └─ licenses: MIT*
 ```
 
+## Changes
+
+### Version 3.0.0
+
+From now on, when you give the `--files` option, this tool outputs the path to the _copied_ license files rather than to
+the originals. When the `relativeLicensePath` option is given, this path will either be relative to the working
+directory or - if also the `out` option is given - relative to the `out` path.
+
+When using the `--out` option, you will not see output in the console, as the output goes into the file specified by
+`--out`. When using the `--files` option without `--out` option, you will now get console output, which was not the case
+before.
+
 ## All options in alphabetical order:
 
 -   `--angularCli` is just a synonym for `--plainVertical`

--- a/bin/license-checker-rseidelsohn
+++ b/bin/license-checker-rseidelsohn
@@ -13,6 +13,7 @@ const mkdirp = require('mkdirp');
 const path = require('path');
 const chalk = require('chalk');
 const fs = require('fs');
+const cloneDeep = require('lodash.clonedeep');
 const hasFailingArg = parsedArgs.failOn || parsedArgs.onlyAllow;
 
 const usageMessage = [
@@ -47,7 +48,7 @@ const usageMessage = [
     '',
     '   --version The current version',
     '   --help The text you are reading right now :)',
-    ''
+    '',
 ].join('\n');
 
 const kownOptions = Object.keys(args.knownOpts);
@@ -55,7 +56,11 @@ const unknownArgs = Object.keys(parsedArgs).filter((arg) => !kownOptions.include
 
 if (unknownArgs.length) {
     console.error(`license-checker-rseidelsohn@${require('../package.json').version}`, '\n');
-    console.error(`Error: Unknown option${unknownArgs.length > 1 ? 's' : ''}: ${unknownArgs.map((unknownArg) => `'${unknownArg}'`).join(', ')}`);
+    console.error(
+        `Error: Unknown option${unknownArgs.length > 1 ? 's' : ''}: ${unknownArgs
+            .map((unknownArg) => `'${unknownArg}'`)
+            .join(', ')}`,
+    );
     console.error(`       Possibly a typo? Currently known options are:`);
     console.error(usageMessage, '\n');
     process.exit(1);
@@ -79,7 +84,9 @@ if (parsedArgs.failOn && parsedArgs.onlyAllow) {
 
 if (hasFailingArg && hasFailingArg.indexOf(',') >= 0) {
     const argName = parsedArgs.failOn ? 'failOn' : 'onlyAllow';
-    console.warn(`Warning: As of v17 the --${argName} argument takes semicolons as delimeters instead of commas (some license names can contain commas)`);
+    console.warn(
+        `Warning: As of v17 the --${argName} argument takes semicolons as delimeters instead of commas (some license names can contain commas)`,
+    );
 }
 
 licenseChecker.init(parsedArgs, function (err, json) {
@@ -105,7 +112,9 @@ licenseChecker.init(parsedArgs, function (err, json) {
             mkdirp.sync(dir);
             fs.writeFileSync(parsedArgs.out, formattedOutput, 'utf8');
         }
-    } else {
+    }
+
+    if (!parsedArgs.out) {
         console.log(formattedOutput);
     }
 });
@@ -117,7 +126,10 @@ function shouldColorizeOutput(args) {
 function colorizeOutput(json) {
     Object.keys(json).forEach((key) => {
         const index = key.lastIndexOf('@');
-        const colorizedKey = chalk.white.bgKeyword('darkslategrey')(key.substr(0, index)) + chalk.dim('@') + chalk.white.bgKeyword('green')(key.substr(index + 1));
+        const colorizedKey =
+            chalk.white.bgKeyword('darkslategrey')(key.substr(0, index)) +
+            chalk.dim('@') +
+            chalk.white.bgKeyword('green')(key.substr(index + 1));
         json[colorizedKey] = json[key];
 
         delete json[key];
@@ -125,25 +137,46 @@ function colorizeOutput(json) {
 }
 
 function getFormattedOutput(json, args) {
+    const jsonCopy = cloneDeep(json);
+
+    if (args.files) {
+        Object.keys(jsonCopy).forEach((moduleName) => {
+            const outPath = path.join(args.files, `${moduleName}-LICENSE.txt`);
+            const originalLicenseFile = jsonCopy[moduleName].licenseFile;
+
+            if (originalLicenseFile && fs.existsSync(originalLicenseFile)) {
+                if (args.relativeLicensePath) {
+                    if (args.out) {
+                        jsonCopy[moduleName].licenseFile = path.relative(args.out, outPath);
+                    } else {
+                        jsonCopy[moduleName].licenseFile = path.relative(process.cwd(), outPath);
+                    }
+                } else {
+                    jsonCopy[moduleName].licenseFile = outPath;
+                }
+            }
+        });
+    }
+
     if (args.json) {
-        return JSON.stringify(json, null, 4) + '\n';
+        return JSON.stringify(jsonCopy, null, 4) + '\n';
     }
 
     if (args.csv) {
-        return licenseChecker.asCSV(json, args.customFormat, args.csvComponentPrefix);
+        return licenseChecker.asCSV(jsonCopy, args.customFormat, args.csvComponentPrefix);
     }
 
-    if (args.markdown){
-        return licenseChecker.asMarkDown(json, args.customFormat) + "\n";
+    if (args.markdown) {
+        return licenseChecker.asMarkDown(jsonCopy, args.customFormat) + '\n';
     }
 
     if (args.summary) {
-        return licenseChecker.asSummary(json);
+        return licenseChecker.asSummary(jsonCopy);
     }
 
     if (args.plainVertical || args.angluarCli) {
-        return licenseChecker.asPlainVertical(json);
+        return licenseChecker.asPlainVertical(jsonCopy);
     }
 
-    return licenseChecker.asTree(json);
+    return licenseChecker.asTree(jsonCopy);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "license-checker-rseidelsohn",
-  "version": "2.4.7",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "license-checker-rseidelsohn",
-      "version": "2.4.7",
+      "version": "3.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "chalk": "^4.1.2",
         "debug": "^4.3.2",
+        "lodash.clonedeep": "^4.5.0",
         "mkdirp": "^1.0.4",
         "nopt": "^5.0.0",
         "read-installed-packages": "^1.0.0",
@@ -2823,6 +2824,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz",
       "integrity": "sha1-AVnoaDL+/8bWHYUrEqlTuZSWvTI=",
       "dev": true
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "node_modules/lodash.flattendeep": {
       "version": "4.4.0",
@@ -7445,6 +7451,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz",
       "integrity": "sha1-AVnoaDL+/8bWHYUrEqlTuZSWvTI=",
       "dev": true
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "lodash.flattendeep": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "license-checker-rseidelsohn",
   "description": "Feature enhanced version of the original license-checker v25.0.1",
   "author": "Roman Seidelsohn <rseidelsohn@gmail.com>",
-  "version": "2.4.8",
+  "version": "3.0.0",
   "license": "BSD-3-Clause",
   "contributors": [
     "Adam Weber <adamweber01@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   "dependencies": {
     "chalk": "^4.1.2",
     "debug": "^4.3.2",
+    "lodash.clonedeep": "^4.5.0",
     "mkdirp": "^1.0.4",
     "nopt": "^5.0.0",
     "read-installed-packages": "^1.0.0",


### PR DESCRIPTION
- When using the `--files` option, the modules' `licenseFile` will contain the path of the licenseFile that was copied into the `--files` directory rather than the path of the original license file.
- When using the `--out` option, no console output will appear.
- When using the `--files` option (without the `--out` option), then now console output will appear, which was not the case before.