### PR TITLE
Fix `--direct` option

### DIFF
--- a/bin/license-checker-rseidelsohn
+++ b/bin/license-checker-rseidelsohn
@@ -127,9 +127,9 @@ function colorizeOutput(json) {
     Object.keys(json).forEach((key) => {
         const index = key.lastIndexOf('@');
         const colorizedKey =
-            chalk.white.bgKeyword('darkslategrey')(key.substr(0, index)) +
+            chalk.white.bgKeyword('darkslategrey')(key.slice(0, index + 1)) +
             chalk.dim('@') +
-            chalk.white.bgKeyword('green')(key.substr(index + 1));
+            chalk.white.bgKeyword('green')(key.slice(index + 1));
         json[colorizedKey] = json[key];
 
         delete json[key];

--- a/lib/index.js
+++ b/lib/index.js
@@ -278,6 +278,38 @@ const flatten = function flatten(options) {
     return data;
 };
 
+/**
+ * ! This function has a wanted sideeffect, as it modifies the json object that is passed by reference.
+ *
+ *  The detph attribute set in the opts parameter here - which is defined by setting the `--direct` flag - is of
+ *  no use with npm > 2, as the newer npm versions flatten all dependencies into one single directory. So in
+ *  order to making `--direct` work with newer versions of npm, we need to filter out all non-dependencies from
+ *  the json result.
+ */
+const removeUnwantedDependencies = (json, args) => {
+    if (args.direct === 0) {
+        const allDependencies = Object.keys(json.dependencies);
+        let wantedDependencies = [];
+
+        if (args.production && !args.development) {
+            const devDependencies = Object.keys(json.devDependencies);
+            wantedDependencies = Object.keys(json._dependencies).filter(
+                (directDependency) => !devDependencies.includes(directDependency),
+            );
+        } else if (!args.production && args.development) {
+            wantedDependencies = Object.keys(json.devDependencies);
+        } else {
+            wantedDependencies = Object.keys(json._dependencies);
+        }
+
+        allDependencies.forEach((currentDependency) => {
+            if (!wantedDependencies.includes(currentDependency)) {
+                delete json.dependencies[currentDependency];
+            }
+        });
+    }
+};
+
 exports.init = function init(args, callback) {
     // Fix path if on Windows:
     const workingDir = args.start.replace(/\\\\/g, '\\');

--- a/lib/index.js
+++ b/lib/index.js
@@ -240,7 +240,7 @@ const flatten = function flatten(options) {
     /*istanbul ignore else*/
     if (json.dependencies) {
         Object.keys(json.dependencies).forEach((name) => {
-            const childDependency = json.dependencies[name];
+            const childDependency = options.depth > options._args.direct ? {} : json.dependencies[name];
             const dependencyId = `${childDependency.name}@${childDependency.version}`;
 
             if (data[dependencyId]) {
@@ -258,6 +258,7 @@ const flatten = function flatten(options) {
                 development: options.development,
                 production: options.production,
                 unknown,
+                depth: options.depth + 1,
             });
         });
     }
@@ -369,7 +370,9 @@ exports.init = function init(args, callback) {
             development: args.development,
             production: args.production,
             unknown: args.unknown,
+            depth: 0,
         });
+
         const colorize = args.color;
         const sorted = {};
         let filtered = {};

--- a/lib/index.js
+++ b/lib/index.js
@@ -357,6 +357,8 @@ exports.init = function init(args, callback) {
     }
 
     read(args.start, opts, (err, json) => {
+        removeUnwantedDependencies(json, args);
+
         const data = flatten({
             _args: args,
             basePath: args.relativeLicensePath ? json.path : null,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "license-checker-rseidelsohn",
   "description": "Feature enhanced version of the original license-checker v25.0.1",
   "author": "Roman Seidelsohn <rseidelsohn@gmail.com>",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "license": "BSD-3-Clause",
   "contributors": [
     "Adam Weber <adamweber01@gmail.com>",


### PR DESCRIPTION
The `--direct` option now only lists direct dependencies and also respects the `--production` and `--development` options.