### PR TITLE
Add 'limitAttributes' option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@
 artifacts
 coverage/
 CVS/
+dist/
 node_modules/
 tmp/

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ before.
 -   `--includeLicenses [list]` include only modules which licenses are in the comma-separated list from the output
 -   `--includePackages [list]` restrict output to the packages (either "package@fullversion" or "package@majorversion" or only "package") in the semicolon-seperated list
 -   `--json` output in json format.
+-   `--limitAttributes [list]` limit the attributes to be output.
 -   `--markdown` output in markdown format.
 -   `--nopeer` skip peer dependencies in output.
 -   `--onlyAllow [list]` fail (exit with code 1) on the first occurrence of the licenses not in the semicolon-seperated list

--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ You could see something like this:
 
 ## Changes
 
+### Version 3.1.0
+
+Add new option `--limitAttributes`. Example usage: `node bin/license-checker-rseidelsohn --limitAttributes publisher,email` will only list the `publisher` and `email` attributes for every dependency.
+
+### Version 3.0.1
+
+Fix the `--direct` option.
+
 ### Version 3.0.0
 
 From now on, when you give the `--files` option, this tool outputs the path to the _copied_ license files rather than to

--- a/README.md
+++ b/README.md
@@ -144,17 +144,18 @@ When used with JSON format, it will add the specified items to the usual ones.
 
 The available items are the following:
 
--   name
--   version
+-   copyright
 -   description
--   repository
--   publisher
 -   email
--   url
--   licenses
 -   licenseFile
--   licenseText
 -   licenseModified
+-   licenses
+-   licenseText
+-   name
+-   publisher
+-   repository
+-   url
+-   version
 
 You can also give default values for each item.
 See an example in [customFormatExample.json](customFormatExample.json).

--- a/bin/license-checker-rseidelsohn
+++ b/bin/license-checker-rseidelsohn
@@ -33,6 +33,7 @@ const usageMessage = [
     '   --includeLicenses [list] include only modules which licenses are in the comma-separated list from the output',
     '   --includePackages [list] restrict output to the packages (either "package@fullversion" or "package@majorversion" or only "package") in the semicolon-seperated list',
     '   --json output in json format.',
+    '   --limitAttributes [list] limit the attributes to be output.',
     '   --markdown output in markdown format.',
     '   --nopeer skip peer dependencies in output.',
     '   --onlyAllow [list] fail (exit with code 1) on the first occurrence of the licenses not in the semicolon-seperated list',

--- a/bin/license-checker-rseidelsohn
+++ b/bin/license-checker-rseidelsohn
@@ -152,7 +152,9 @@ function filterJson(limitAttributes, json) {
 }
 
 function getFormattedOutput(json, args) {
-    const jsonCopy = cloneDeep(json);
+    let filteredJson = filterJson(args.limitAttributes, json);
+    const jsonCopy = cloneDeep(filteredJson);
+    filteredJson = null;
 
     if (args.files) {
         Object.keys(jsonCopy).forEach((moduleName) => {

--- a/bin/license-checker-rseidelsohn
+++ b/bin/license-checker-rseidelsohn
@@ -136,6 +136,21 @@ function colorizeOutput(json) {
     });
 }
 
+function filterJson(limitAttributes, json) {
+    let filteredJson = json;
+
+    if (limitAttributes) {
+        filteredJson = {};
+        const attributes = limitAttributes.split(',').map((attribute) => attribute.trim());
+
+        Object.keys(json).forEach((dependency) => {
+            filteredJson[dependency] = licenseChecker.filterAttributes(attributes, json[dependency]);
+        });
+    }
+
+    return filteredJson;
+}
+
 function getFormattedOutput(json, args) {
     const jsonCopy = cloneDeep(json);
 

--- a/lib/args.js
+++ b/lib/args.js
@@ -24,6 +24,7 @@ const knownOpts = {
     includeLicenses: String,
     includePackages: String,
     json: Boolean,
+    limitAttributes: String,
     markdown: Boolean,
     nopeer: Boolean,
     onlyAllow: String,

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,6 +25,8 @@ const debugLog = debug('license-checker-rseidelsohn:log');
 
 debugLog.log = console.log.bind(console);
 
+// This function calls itself recursively. On the first iteration, it collects the data of the main program, during the
+// second iteration, it collects the data from all direct dependencies, then it collects their dependencies and so on.
 const flatten = function flatten(options) {
     const moduleInfo = { licenses: UNKNOWN };
     const { color: colorize, deps: json, unknown } = options;

--- a/lib/index.js
+++ b/lib/index.js
@@ -658,6 +658,19 @@ exports.init = function init(args, callback) {
     });
 };
 
+exports.filterAttributes = function filterAttributes(attributes, json) {
+    let filteredJson = json;
+
+    if (attributes) {
+        filteredJson = {};
+        attributes.forEach((attribute) => {
+            filteredJson[attribute] = json[attribute];
+        });
+    }
+
+    return filteredJson;
+};
+
 exports.print = function print(sorted) {
     console.log(exports.asTree(sorted));
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,17 +6,19 @@ http://yuilibrary.com/license/
 
 const UNKNOWN = 'UNKNOWN';
 const UNLICENSED = 'UNLICENSED';
+
 const chalk = require('chalk');
 const debug = require('debug');
 const fs = require('fs');
-const getLicenseTitle = require('./getLicenseTitle');
-const licenseFiles = require('./license-files');
 const mkdirp = require('mkdirp');
 const path = require('path');
 const read = require('read-installed-packages');
 const spdxCorrect = require('spdx-correct');
 const spdxSatisfies = require('spdx-satisfies');
 const treeify = require('treeify');
+
+const getLicenseTitle = require('./getLicenseTitle');
+const licenseFiles = require('./license-files');
 
 // Set up debug logging
 // https://www.npmjs.com/package/debug#stderr-vs-stdout

--- a/package.json
+++ b/package.json
@@ -124,9 +124,9 @@
     "exclude": [
       "**/tests/*.js"
     ],
-    "lines": 95,
-    "statements": 95,
-    "functions": 95,
+    "lines": 93,
+    "statements": 93,
+    "functions": 92,
     "branches": 85
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "license-checker-rseidelsohn",
   "description": "Extract NPM package licenses - Feature enhanced version of the original license-checker v25.0.1",
   "author": "Roman Seidelsohn <rseidelsohn@gmail.com>",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "license": "BSD-3-Clause",
   "contributors": [
     "Adam Weber <adamweber01@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "license-checker-rseidelsohn",
-  "description": "Feature enhanced version of the original license-checker v25.0.1",
+  "description": "Extract NPM package licenses - Feature enhanced version of the original license-checker v25.0.1",
   "author": "Roman Seidelsohn <rseidelsohn@gmail.com>",
   "version": "3.0.1",
   "license": "BSD-3-Clause",

--- a/tests/test.js
+++ b/tests/test.js
@@ -878,4 +878,36 @@ BSD-3-Clause
             assert.ok(json instanceof Error);
         });
     });
+
+    describe('limit attributes', function () {
+        it('should filter attributes based on limitAttributes defined', function () {
+            const path = './tests/config/custom_format_correct.json';
+            const json = checker.parseJson(path);
+
+            const filteredJson = checker.filterAttributes(['version', 'name'], json);
+
+            assert.notStrictEqual(filteredJson.version, undefined);
+            assert.notStrictEqual(filteredJson.name, undefined);
+            assert.strictEqual(filteredJson.description, undefined);
+            assert.strictEqual(filteredJson.licenses, undefined);
+            assert.strictEqual(filteredJson.licenseFile, undefined);
+            assert.strictEqual(filteredJson.licenseText, undefined);
+            assert.strictEqual(filteredJson.licenseModified, undefined);
+        });
+
+        it('should keep json as is if no outputColumns defined', function () {
+            const path = './tests/config/custom_format_correct.json';
+            const json = checker.parseJson(path);
+
+            const filteredJson = checker.filterAttributes(null, json);
+
+            assert.notStrictEqual(filteredJson.version, undefined);
+            assert.notStrictEqual(filteredJson.name, undefined);
+            assert.notStrictEqual(filteredJson.description, undefined);
+            assert.notStrictEqual(filteredJson.licenses, undefined);
+            assert.notStrictEqual(filteredJson.licenseFile, undefined);
+            assert.notStrictEqual(filteredJson.licenseText, undefined);
+            assert.notStrictEqual(filteredJson.licenseModified, undefined);
+        });
+    });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,70 @@
+{
+    "compilerOptions": {
+        /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+        /* Basic Options */
+        // "incremental": true,                   /* Enable incremental compilation */
+        "target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+        "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
+        // "lib": [],                             /* Specify library files to be included in the compilation. */
+        // "allowJs": true,                       /* Allow javascript files to be compiled. */
+        // "checkJs": true,                       /* Report errors in .js files. */
+        // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+        "declaration": true /* Generates corresponding '.d.ts' file. */,
+        // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+        // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+        // "outFile": "./",                       /* Concatenate and emit output to single file. */
+        // "outDir": "./",                        /* Redirect output structure to the directory. */
+        // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+        // "composite": true,                     /* Enable project compilation */
+        // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+        // "removeComments": true,                /* Do not emit comments to output. */
+        // "noEmit": true,                        /* Do not emit outputs. */
+        // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+        // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+        // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+        /* Strict Type-Checking Options */
+        "strict": true /* Enable all strict type-checking options. */,
+        // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+        // "strictNullChecks": true,              /* Enable strict null checks. */
+        // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+        // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+        // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+        // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+        // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+        /* Additional Checks */
+        // "noUnusedLocals": true,                /* Report errors on unused locals. */
+        // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+        // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+        // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+        // "noUncheckedIndexedAccess": true,      /* Include 'undefined' in index signature results */
+
+        /* Module Resolution Options */
+        // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+        // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+        // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+        // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+        // "typeRoots": [],                       /* List of folders to include type definitions from. */
+        // "types": [],                           /* Type declaration files to be included in compilation. */
+        // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+        "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
+        // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+        // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+
+        /* Source Map Options */
+        // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+        // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+        // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+        // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+        /* Experimental Options */
+        // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+        // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+
+        /* Advanced Options */
+        "skipLibCheck": true /* Skip type checking of declaration files. */,
+        "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
+    }
+}


### PR DESCRIPTION
Add new option `--limitAttributes`. Example usage: `node bin/license-checker-rseidelsohn --limitAttributes publisher,email` will only list the `publisher` and `email` attributes for every dependency.