### PR TITLE
Add flag `--excludePackagesStartingWith [list]` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,21 @@
 
 ## Table of Contents
 
-- [Introduction](#introduction)
-- [Changes](#changes)
-- [All options in alphabetical order](#all_options_in_alphabetical_order)
-- [Exclusions](#exclusions)
-- [Examples](#examples)
-- [Custom format](#custom_format)
-- [Requiring](#requiring)
-- [Debugging](#debugging)
-- [Related information sources on the internet](#all_options_in_alphabetical_order)
+- [NPM License Checker](#npm-license-checker)
+  - [Table of Contents](#table-of-contents)
+  - [Introduction](#introduction)
+  - [Changes](#changes)
+    - [Version 3.1.0](#version-310)
+    - [Version 3.0.1](#version-301)
+    - [Version 3.0.0](#version-300)
+  - [All options in alphabetical order:](#all-options-in-alphabetical-order)
+  - [Exclusions](#exclusions)
+  - [Examples](#examples)
+  - [Custom format](#custom-format)
+  - [Requiring](#requiring)
+  - [Debugging](#debugging)
+  - [How Licenses are Found](#how-licenses-are-found)
+  - [Related information sources on the internet](#related-information-sources-on-the-internet)
 
 <a name="introduction"/>
 
@@ -119,6 +125,7 @@ before.
 -   `--direct` look for direct dependencies only
 -   `--excludeLicenses [list]` exclude modules which licenses are in the comma-separated list from the output
 -   `--excludePackages [list]` restrict output to the packages (either "package@fullversion" or "package@majorversion" or only "package") not in the semicolon-seperated list
+-   `--excludePackagesStartingWith [list]` exclude modules which names start with the comma-separated list from the output (useful for excluding modules from a specific vendor and such). Example: `--excludePackagesStartingWith "webpack;@types;@babel"`
 -   `--excludePrivatePackages` restrict output to not include any package marked as private
 -   `--failOn [list]` fail (exit with code 1) on the first occurrence of the licenses of the semicolon-separated list
 -   `--files [path]` copy all license files to path and rename them to `module-name`@`version`-LICENSE.txt.

--- a/bin/license-checker-rseidelsohn
+++ b/bin/license-checker-rseidelsohn
@@ -27,6 +27,7 @@ const usageMessage = [
     '   --direct look for direct dependencies only',
     '   --excludeLicenses [list] exclude modules which licenses are in the comma-separated list from the output',
     '   --excludePackages [list] restrict output to the packages (either "package@fullversion" or "package@majorversion" or only "package") not in the semicolon-seperated list',
+    '   --excludePackageStartingWith [list] excludes packages starting with anything the comma-separated list',
     '   --excludePrivatePackages restrict output to not include any package marked as private',
     '   --failOn [list] fail (exit with code 1) on the first occurrence of the licenses of the semicolon-separated list',
     '   --files [path] copy all license files to path and rename them to `module-name`@`version`-LICENSE.txt.',

--- a/lib/args.js
+++ b/lib/args.js
@@ -17,6 +17,7 @@ const knownOpts = {
     direct: Boolean,
     excludeLicenses: String,
     excludePackages: String,
+    excludePackagesStartingWith: String,
     excludePrivatePackages: Boolean,
     failOn: String,
     files: require('path'),

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,7 +1,7 @@
 /**
  * Options struct for the init() function
  */
- export interface InitOpts {
+export interface InitOpts {
     /**
      * Path to start checking dependencies from
      */
@@ -74,6 +74,10 @@
      * Restrict output to not include any package marked as private
      */
     excludePrivatePackages?: boolean | undefined;
+    /**
+     * Exclude modules starting with a specific string
+     */
+    excludePackagesStartingWith?: string | undefined;
     /**
      * Look for direct dependencies only
      */
@@ -167,7 +171,4 @@ export interface ModuleInfos {
  * Run the license check
  * @param opts specifies the path to the module to check dependencies of
  */
-export function init(
-    opts: InitOpts,
-    callback: (err: Error, ret: ModuleInfos) => void
-): void;
+export function init(opts: InitOpts, callback: (err: Error, ret: ModuleInfos) => void): void;

--- a/lib/index.js
+++ b/lib/index.js
@@ -448,6 +448,22 @@ exports.init = function init(args, callback) {
             return resultJson;
         }
 
+        function excludePackagesStartingWith(blacklist, filtered) {
+            const resultJson = {};
+
+            Object.keys(filtered).map((filteredPackage) => {
+                blacklist.forEach((blacklist) => {
+                    if (!filteredPackage.startsWith(blacklist)) {
+                        resultJson[filteredPackage] = filtered[filteredPackage];
+                    } else {
+                        delete filtered[filteredPackage];
+                    }
+                });
+            });
+
+            return resultJson;
+        }
+
         function exitIfCheckHits(packageName) {
             const currentLicense = resultJson[packageName].licenses;
 
@@ -639,6 +655,12 @@ exports.init = function init(args, callback) {
         const blacklist = getOptionArray(args.excludePackages);
         if (blacklist) {
             resultJson = excludeBlacklist(blacklist, filtered);
+        }
+
+        // exclude by package name starting with a string
+        const excludeStartString = getOptionArray(args.excludePackagesStartingWith);
+        if (excludeStartString) {
+            resultJson = excludePackagesStartingWith(excludeStartString, filtered);
         }
 
         if (args.excludePrivatePackages) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "license-checker-rseidelsohn",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "license-checker-rseidelsohn",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -840,9 +840,9 @@
       }
     },
     "node_modules/cliui/node_modules/ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -1758,13 +1758,13 @@
       }
     },
     "node_modules/git-contributors": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/git-contributors/-/git-contributors-0.2.3.tgz",
-      "integrity": "sha1-Atx8t3wSVnFuSvsDMSZ8AvcOWBU=",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/git-contributors/-/git-contributors-0.2.5.tgz",
+      "integrity": "sha512-x3wb3oQ4KYJGLJqCp+a1+hd7W1e6kNYhOE+bXO5VzCZK8oSCVQbosrN4Cg8ZiJofW4xp5MQsaZJdKI1rl+9p3g==",
       "dev": true,
       "dependencies": {
         "commander": "~2.8.1",
-        "lodash": "~3.9.3",
+        "lodash": "^4.17.21",
         "q": "~2.0.3"
       },
       "bin": {
@@ -1797,12 +1797,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/github-changes/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
     },
     "node_modules/github-changes/node_modules/semver": {
       "version": "6.3.0",
@@ -2820,9 +2814,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz",
-      "integrity": "sha1-AVnoaDL+/8bWHYUrEqlTuZSWvTI=",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "node_modules/lodash.clonedeep": {
@@ -3018,10 +3012,13 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",
@@ -3130,6 +3127,18 @@
         "node": "*"
       }
     },
+    "node_modules/mocha/node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/mocha/node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -3205,18 +3214,18 @@
       }
     },
     "node_modules/moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
       "dev": true,
       "engines": {
         "node": "*"
       }
     },
     "node_modules/moment-timezone": {
-      "version": "0.5.34",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.34.tgz",
-      "integrity": "sha512-3zAEHh2hKUs3EXLESx/wsgw6IQdusOT8Bxm3D9UrHPQR7zlMmzwybC8zHEM1tQ4LJwP7fcxrWr8tuBg05fFCbg==",
+      "version": "0.5.39",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.39.tgz",
+      "integrity": "sha512-hoB6suq4ISDj7BDgctiOy6zljBsdYT0++0ZzZm9rtxIvJhIbQ3nmbgSWe7dNFGurl6/7b1OUkHlmN9JWgXVz7w==",
       "dev": true,
       "dependencies": {
         "moment": ">= 2.9.0"
@@ -4624,9 +4633,9 @@
       }
     },
     "node_modules/string-width/node_modules/ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -5043,9 +5052,9 @@
       }
     },
     "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -5238,16 +5247,10 @@
         "node": ">=6"
       }
     },
-    "node_modules/yargs-unparser/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
-    },
     "node_modules/yargs/node_modules/ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -5936,9 +5939,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
           "dev": true
         },
         "string-width": {
@@ -6662,13 +6665,13 @@
       }
     },
     "git-contributors": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/git-contributors/-/git-contributors-0.2.3.tgz",
-      "integrity": "sha1-Atx8t3wSVnFuSvsDMSZ8AvcOWBU=",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/git-contributors/-/git-contributors-0.2.5.tgz",
+      "integrity": "sha512-x3wb3oQ4KYJGLJqCp+a1+hd7W1e6kNYhOE+bXO5VzCZK8oSCVQbosrN4Cg8ZiJofW4xp5MQsaZJdKI1rl+9p3g==",
       "dev": true,
       "requires": {
         "commander": "~2.8.1",
-        "lodash": "~3.9.3",
+        "lodash": "^4.17.21",
         "q": "~2.0.3"
       }
     },
@@ -6691,12 +6694,6 @@
           "version": "6.2.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
           "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
-          "dev": true
-        },
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
           "dev": true
         },
         "semver": {
@@ -7447,9 +7444,9 @@
       }
     },
     "lodash": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz",
-      "integrity": "sha1-AVnoaDL+/8bWHYUrEqlTuZSWvTI=",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "lodash.clonedeep": {
@@ -7609,9 +7606,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
       "dev": true
     },
     "mkdirp": {
@@ -7692,6 +7689,17 @@
             "minimatch": "^3.0.4",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
+          },
+          "dependencies": {
+            "minimatch": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+              "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+              "dev": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            }
           }
         },
         "has-flag": {
@@ -7752,15 +7760,15 @@
       }
     },
     "moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
       "dev": true
     },
     "moment-timezone": {
-      "version": "0.5.34",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.34.tgz",
-      "integrity": "sha512-3zAEHh2hKUs3EXLESx/wsgw6IQdusOT8Bxm3D9UrHPQR7zlMmzwybC8zHEM1tQ4LJwP7fcxrWr8tuBg05fFCbg==",
+      "version": "0.5.39",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.39.tgz",
+      "integrity": "sha512-hoB6suq4ISDj7BDgctiOy6zljBsdYT0++0ZzZm9rtxIvJhIbQ3nmbgSWe7dNFGurl6/7b1OUkHlmN9JWgXVz7w==",
       "dev": true,
       "requires": {
         "moment": ">= 2.9.0"
@@ -8858,9 +8866,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+          "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
           "dev": true
         },
         "strip-ansi": {
@@ -9187,9 +9195,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
           "dev": true
         },
         "ansi-styles": {
@@ -9333,9 +9341,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
           "dev": true
         },
         "string-width": {
@@ -9379,14 +9387,6 @@
         "flat": "^4.1.0",
         "lodash": "^4.17.15",
         "yargs": "^13.3.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-          "dev": true
-        }
       }
     }
   }

--- a/tests/packages-test.js
+++ b/tests/packages-test.js
@@ -45,6 +45,38 @@ describe('bin/license-checker-rseidelsohn', function () {
         });
     });
 
+    it('should exclude packages starting with', function () {
+        const excludedPackages = ['@types', 'spdx'];
+        const output = spawn(
+            'node',
+            [
+                path.join(__dirname, '../bin/license-checker-rseidelsohn'),
+                '--json',
+                '--excludePackagesStartingWith',
+                excludedPackages.join(';'),
+            ],
+            {
+                cwd: path.join(__dirname, '../'),
+            },
+        );
+
+        const packages = Object.keys(JSON.parse(output.stdout.toString()));
+
+        let illegalPackageFound = false;
+
+        // Loop through all packages and check if they start with one of the excluded packages
+        packages.forEach(function (p) {
+            excludedPackages.forEach(function (excludedPackage) {
+                if (p.startsWith(excludedPackage)) {
+                    illegalPackageFound = true;
+                }
+            });
+        });
+
+        // If an illegal package was found, the test fails
+        assert.ok(!illegalPackageFound);
+    });
+
     it('should exclude private packages from the output', function () {
         var output = spawn(
             'node',


### PR DESCRIPTION
Added a way to exclude packages matching a given string. This is useful for excluding all packages form a specifc vendor or all internal packages that might be prefixed with a specific string, like `@<company>/<packagename>`which can be excluded alltogether with this flag: `--excludePackagesStartingWith '@<company>'` instead of adding **all** packages made by this company to the existing flag `--excludePackages`

@RSeidelsohn 