### PR TITLE
Fix: allow to combine excludePackages and excludePackagesStartingWith options

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -448,24 +448,14 @@ exports.init = function init(args, callback) {
             return resultJson;
         }
 
-        function excludePackagesStartingWith(blacklist, filtered) {
-            const resultJson = {};
+        function excludePackagesStartingWith(blacklist, currentResult) {
+            const resultJson = { ...currentResult };
 
-            Object.keys(filtered).map((filteredPackage) => {
-                let isBlacklisted = false;
-
-                blacklist.forEach((blacklisted) => {
-                    if (filteredPackage.startsWith(blacklisted)) {
-                        isBlacklisted = true;
-                    }
-                });
-
-                if (isBlacklisted) {
-                    delete filtered[filteredPackage];
-                } else {
-                    resultJson[filteredPackage] = filtered[filteredPackage];
+            for(const pkgName in resultJson){
+                for(const denyPrefix of blacklist){
+                    if (pkgName.startsWith(denyPrefix)) delete resultJson[pkgName];
                 }
-            });
+            }
 
             return resultJson;
         }
@@ -656,23 +646,23 @@ exports.init = function init(args, callback) {
         // package whitelist
         const whitelist = getOptionArray(args.includePackages);
         if (whitelist) {
-            resultJson = onlyIncludeWhitelist(whitelist, filtered);
+            resultJson = onlyIncludeWhitelist(whitelist, resultJson);
         }
 
         // package blacklist
         const blacklist = getOptionArray(args.excludePackages);
         if (blacklist) {
-            resultJson = excludeBlacklist(blacklist, filtered);
+            resultJson = excludeBlacklist(blacklist, resultJson);
         }
 
         // exclude by package name starting with a string
         const excludeStartStringsArr = getOptionArray(args.excludePackagesStartingWith);
         if (excludeStartStringsArr) {
-            resultJson = excludePackagesStartingWith(excludeStartStringsArr, filtered);
+            resultJson = excludePackagesStartingWith(excludeStartStringsArr, resultJson);
         }
 
         if (args.excludePrivatePackages) {
-            Object.keys(filtered).forEach(filterDeletePrivatePackages);
+            Object.keys(resultJson).forEach(filterDeletePrivatePackages);
         }
 
         Object.keys(resultJson).forEach(exitIfCheckHits);

--- a/tests/packages-test.js
+++ b/tests/packages-test.js
@@ -77,6 +77,48 @@ describe('bin/license-checker-rseidelsohn', function () {
         assert.ok(!illegalPackageFound);
     });
 
+
+    it('should combine various types of inclusion and exclusions', function () {
+        const excludedPrefix = ['@types', 'spdx'];
+        const excludedNames = ['rimraf'];
+        const output = spawn(
+            'node',
+            [
+                path.join(__dirname, '../bin/license-checker-rseidelsohn'),
+                '--json',
+                '--excludePackages',
+                excludedNames.join(';'),
+                '--excludePackagesStartingWith',
+                excludedPrefix.join(';'),
+            ],
+            {
+                cwd: path.join(__dirname, '../'),
+            },
+        );
+        const packages = Object.keys(JSON.parse(output.stdout.toString()));
+
+        let illegalPackageFound = false;
+
+        packages.forEach(function (p) {
+            excludedNames.forEach(function (pkgName) {
+                if(pkgName.indexOf('@')>1){
+                    // check for the exact version
+                    if(p === pkgName) illegalPackageFound = true;
+                } else if (p.startsWith(`${pkgName}@`)) {
+                    illegalPackageFound = true;
+                }
+            });
+            excludedPrefix.forEach(function (prefix) {
+                if (p.startsWith(prefix)) {
+                    illegalPackageFound = true;
+                }
+            });
+        });
+
+        // If an illegal package was found, the test fails
+        assert.ok(!illegalPackageFound);
+    });
+
     it('should exclude private packages from the output', function () {
         var output = spawn(
             'node',


### PR DESCRIPTION
This PR makes it possible to combine the two different methods of excluding packages from evaluation (`excludePackages` and `excludePackagesStartingWith`).

Also fixes the incorrect behavior of `excludePackagesStartingWith` which resulted in the failed test at https://github.com/RSeidelsohn/license-checker-rseidelsohn/actions/runs/3924255813

Fixes #49 