### PR TITLE
Allow npm versions higher than 8 as well

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "BSD-3-Clause",
   "private": false,
   "engines": {
-    "npm": "^8",
+    "npm": ">=8",
     "node": ">=18"
   },
   "engine-strict": true,


### PR DESCRIPTION
I made a mistake by restricting the npm major version to be 8 only. This is fixed now.