### PR TITLE
fix: parse direct also inside init to make it work in programmatic usage

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -185,7 +185,7 @@ const flatten = function flatten(options) {
         });
     }
 
-    files.forEach(function(filename, index) {
+    files.forEach(function (filename, index) {
         licenseFile = path.join(module_path, filename);
         // Checking that the file is in fact a normal file and not a directory for example.
         /*istanbul ignore else*/
@@ -393,7 +393,18 @@ const removeUnwantedDependencies = (json, args) => {
     }
 };
 
-exports.init = function init(args, callback) {
+function prepareArgs(args) {
+    const normalizedArgs = { ...args };
+    if (args.direct === true) {
+        normalizedArgs.direct = 0;
+    } else if (typeof args.direct !== 'number') {
+        normalizedArgs.direct = Infinity;
+    }
+    return normalizedArgs;
+}
+
+exports.init = function init(initArgs, callback) {
+    const args = prepareArgs(initArgs);
     // Fix path if on Windows:
     const workingDir = args.start.replace(/\\\\/g, '\\');
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -5,6 +5,8 @@ const checker = require('../lib/index');
 let args = require('../lib/args');
 const chalk = require('chalk');
 const fs = require('fs');
+const pkgPath = path.join(__dirname, '../package.json');
+const pkgJson = require(pkgPath);
 
 describe('main tests', function () {
     it('should load init', function () {
@@ -137,6 +139,34 @@ describe('main tests', function () {
         it('should give us results', function () {
             assert.ok(output);
             assert.ok(Object.keys(output).length > 20);
+        });
+    });
+
+    describe('should parse direct dependencies only', function () {
+        let output;
+
+        before(function (done) {
+            checker.init(
+                {
+                    start: path.join(__dirname, '../'),
+                    direct: true,
+                },
+                function (err, sorted) {
+                    output = sorted;
+                    done();
+                },
+            );
+        });
+
+        it('and give us results', function () {
+            const pkgDepsNumber =
+                Object.keys(pkgJson.dependencies || {}).length +
+                Object.keys(pkgJson.devDependencies || {}).length +
+                Object.keys(pkgJson.peerDependencies || {}).length;
+            // all and only the dependencies listed in the package.json should be included in the output,
+            // plus the main module itself
+            assert.ok(Object.keys(output).length === pkgDepsNumber + 1);
+            assert.equal(output['abbrev@1.0.9'], undefined);
         });
     });
 


### PR DESCRIPTION
To keep the same interface between the arguments passed through the cli, and the arguments passed throught the programmatic usage, the declaration of the init function define the direct arg as a boolean.
This is not entirerly true in the usage from the cli, since inside the parse function, the direct argument is converted to a number (0 or Infinite).

In order to make both the usages work with the same interface for the args, the PR adds an additional function in charge of preparing the arguments for being used in the core logic.

Specifically for this case, the direct argument is converted from a boolean to an integer as done in the setDefaults for the cli usage, only when it arrives from the init as true, or as someting differnt from a number.

fixes #35 