### PR TITLE
fix: add failing test for custom license URL

### DIFF
--- a/tests/fixtures/custom-license-url/README.md
+++ b/tests/fixtures/custom-license-url/README.md
@@ -1,0 +1,1 @@
+http://totally.not.a.valid.license.com/banana


### PR DESCRIPTION
Shows a failing test for #63 