### PR TITLE
Release 4.2.2

### DIFF
--- a/lib/licenseCheckerHelpers.js
+++ b/lib/licenseCheckerHelpers.js
@@ -50,7 +50,7 @@ const getFormattedOutput = function getFormattedOutput(json, args) {
             if (originalLicenseFile && fs.existsSync(originalLicenseFile)) {
                 if (args.relativeLicensePath) {
                     if (args.out) {
-                        jsonCopy[moduleName].licenseFile = path.relative(args.out, outPath);
+                        jsonCopy[moduleName].licenseFile = path.relative(path.dirname(args.out), outPath);
                     } else {
                         jsonCopy[moduleName].licenseFile = path.relative(process.cwd(), outPath);
                     }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "license-checker-rseidelsohn",
   "description": "Extract NPM package licenses - Feature enhanced version of the original license-checker v25.0.1",
   "author": "Roman Seidelsohn <rseidelsohn@gmail.com>",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "license": "BSD-3-Clause",
   "private": false,
   "engines": {


### PR DESCRIPTION
fix: Fix relative path calculation

The first argument to path.relative has to be a path, not a full
file path. Kudos to @denniseffing