### PR TITLE
Release 4.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ You could see something like this:
 
 ## Changes (see a more detailed and always up-to-date list [here](https://github.com/RSeidelsohn/license-checker-rseidelsohn/releases))
 
+### Version 4.2.4
+
+Improve the detection of URLs as licenses which are no licenses at all. Previously, when no license info could be found elsewhere, any URL in the README was taken as a custom license, which is not a very bulletproof method. Now, I restrict this method which was probably meant as a fallback solution to only being considered if the README contains at least the word "license" in some form (or notation). Not good, but better than before.
 ### Version 4.2.3
 
 Fix `--relativeModulePath` not working in combination with `--start`.

--- a/lib/getLicenseTitle.js
+++ b/lib/getLicenseTitle.js
@@ -21,7 +21,8 @@ const CC0_1_0 =
     /The\s+person\s+who\s+associated\s+a\s+work\s+with\s+this\s+deed\s+has\s+dedicated\s+the\s+work\s+to\s+the\s+public\s+domain\s+by\s+waiving\s+all\s+of\s+his\s+or\s+her\s+rights\s+to\s+the\s+work\s+worldwide\s+under\s+copyright\s+law,\s+including\s+all\s+related\s+and\s+neighboring\s+rights,\s+to\s+the\s+extent\s+allowed\s+by\s+law.\s+You\s+can\s+copy,\s+modify,\s+distribute\s+and\s+perform\s+the\s+work,\s+even\s+for\s+commercial\s+purposes,\s+all\s+without\s+asking\s+permission./i; // jshint ignore:line
 const PUBLIC_DOMAIN = /[Pp]ublic[\-_ ]*[Dd]omain/;
 const IS_URL = /(https?:\/\/[-a-zA-Z0-9\/.]*)/;
-const DISCARD_URLS_ENDING_WITH = /(.svg|.gif|.png|.jpg|.jpeg)$/i;
+const CONTAINS_URLS_ENDING_WITH = /(.svg|.gif|.png|.jpg|.jpeg)$/i;
+const CONTAINS_LICENSE_TERM = /(license|licence|lizenz)/gi;
 const IS_FILE_REFERENCE = /SEE LICENSE IN (.*)/i;
 const UNLICENSED = /UNLICENSED/i;
 
@@ -162,11 +163,13 @@ module.exports = function getLicenseTitle(str = 'undefined') {
 
     if (match) {
         const matchedUrl = match[1];
+        CONTAINS_LICENSE_TERM.lastIndex = 0;
+        CONTAINS_URLS_ENDING_WITH.lastIndex = 0;
 
-        if (!DISCARD_URLS_ENDING_WITH.test(matchedUrl)) {
+        if (CONTAINS_LICENSE_TERM.test(str) && !CONTAINS_URLS_ENDING_WITH.test(matchedUrl)) {
             return `Custom: ${matchedUrl}`;
         }
-    } else {
-        return null;
     }
+
+    return null;
 };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "license-checker-rseidelsohn",
   "description": "Extract NPM package licenses - Feature enhanced version of the original license-checker v25.0.1",
   "author": "Roman Seidelsohn <rseidelsohn@gmail.com>",
-  "version": "4.2.3",
+  "version": "4.2.4",
   "license": "BSD-3-Clause",
   "private": false,
   "engines": {

--- a/tests/getLicenseTitle.js
+++ b/tests/getLicenseTitle.js
@@ -159,12 +159,19 @@ describe('license parser', function () {
     });
 
     it('License at URL check', function () {
-        let data = getLicenseTitle('http://example.com/foo');
+        let data = getLicenseTitle('License: http://example.com/foo');
         assert.equal(data, 'Custom: http://example.com/foo');
         data = getLicenseTitle('See license at http://example.com/foo');
         assert.equal(data, 'Custom: http://example.com/foo');
-        data = getLicenseTitle('https://example.com/foo');
+        data = getLicenseTitle('license: https://example.com/foo');
         assert.equal(data, 'Custom: https://example.com/foo');
+    });
+
+    it('Likely not a license at URL check', function () {
+        let data = getLicenseTitle('http://example.com/foo');
+        assert.equal(data, null);
+        data = getLicenseTitle('See at http://example.com/foo');
+        assert.equal(data, null);
     });
 
     it('License at file check', function () {


### PR DESCRIPTION
Improve the detection of URLs as licenses which are no licenses at all.
Previously, when no license info could be found elsewhere, any URL in
the README was taken as a custom license, which is not a very
bulletproof method. Now, I restrict this method which was probably meant
as a fallback solution to only being considered if the README contains
at least the word "license" in some form (or notation). Not good, but
better than before.