### PR TITLE
fix: methods from exports instead of global this

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -363,7 +363,7 @@ exports.init = function init(args, callback) {
 
     // customPath is a path to a JSON file that defined a custom format
     if (args.customPath) {
-        args.customFormat = this.parseJson(args.customPath);
+        args.customFormat = exports.parseJson(args.customPath);
     }
 
     const optionsForReadingInstalledPackages = {
@@ -395,7 +395,7 @@ exports.init = function init(args, callback) {
     // An object mapping from Package name -> What contents it should have
     let clarifications = {};
     if (args.clarificationsFile) {
-        clarifications = this.parseJson(args.clarificationsFile);
+        clarifications = exports.parseJson(args.clarificationsFile);
     }
 
     if (checker && pusher) {
@@ -728,7 +728,7 @@ exports.init = function init(args, callback) {
             inputError = err;
         } else {
             // Output to files, if necessary
-            this.writeOutput(args, resultJson);
+            exports.writeOutput(args, resultJson);
         }
 
         // Return the callback and variables nicely
@@ -917,7 +917,7 @@ exports.writeOutput = function (parsedArgs, foundLicensesJson) {
         const formattedOutput = licenseCheckerHelpers.getFormattedOutput(foundLicensesJson, parsedArgs);
 
         if (parsedArgs.files) {
-            this.asFiles(foundLicensesJson, parsedArgs.files);
+            exports.asFiles(foundLicensesJson, parsedArgs.files);
         }
 
         if (parsedArgs.out) {


### PR DESCRIPTION
closes https://github.com/RSeidelsohn/license-checker-rseidelsohn/issues/95