### PR TITLE
chore: only include necessary files in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,6 +126,12 @@
     "tbbstny <tbbstny@users.noreply.github.com>",
     "zodiac403 <zodiac403@gmx.de>"
   ],
+  "files": [
+    "bin",
+    "lib",
+    "CHANGELOG.md",
+    "SECURITY.md"
+  ],
   "dependencies": {
     "chalk": "4.1.2",
     "debug": "^4.3.4",


### PR DESCRIPTION
Fixes #89 

Explicitly lists the files that should be included in the package, so the test files are excluded. This also makes the .npmignore file obsolete, so I deleted it.