### PR TITLE
Add files allow-list in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "bin": {
     "license-checker-rseidelsohn": "./bin/license-checker-rseidelsohn"
   },
+  "files": ["lib"],
   "scripts": {
     "changes": "github-changes -o RSeidelsohn -r license-checker-rseidelsohn",
     "contrib": "node ./scripts/contrib.js",


### PR DESCRIPTION
The current released version of the package contains a "test" directory with a total size of 146.9MiB. It contains a bunch of unrelated NPM packages in a node_modules directory, for instance angular.

I suspect this directory is local to the maintainer's machine and not meant to be included in NPM releases. To prevent this from happening, add a "files" allow-list to only include what's needed for the package to run in the output of "npm pack".