### PR TITLE
Fix path to executable

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",
     "bin": {
-        "license-checker-rseidelsohn": "./bin/license-checker-rseidelsohn"
+        "license-checker-rseidelsohn": "./bin/license-checker-rseidelsohn.js"
     },
     "scripts": {
         "changes": "github-changes -o RSeidelsohn -r license-checker-rseidelsohn",


### PR DESCRIPTION
Fix the path declaration for `bin` in package.json. This should fix running directly using npx.

Tried running this and it worked again: `npx https://github.com/kriths/license-checker-rseidelsohn --json --production`

Fixes: #118 