### PR TITLE
fix(cli): use getNormalizedArguments instead of removed parse

### DIFF
--- a/bin/license-checker-rseidelsohn.js
+++ b/bin/license-checker-rseidelsohn.js
@@ -11,7 +11,7 @@ import { exitProcessOrWarnIfNeeded } from '../lib/exitProcessOrWarnIfNeeded.js';
 import * as helpers from '../lib/licenseCheckerHelpers.js';
 import * as licenseCheckerMain from '../lib/index.js';
 
-const parsedArgs = args.parse();
+const parsedArgs = args.getNormalizedArguments();
 const hasFailingArg = parsedArgs.failOn || parsedArgs.onlyAllow;
 const kownOptions = Object.keys(args.knownOptions);
 const unknownArgs = Object.keys(parsedArgs).filter((arg) => !kownOptions.includes(arg));


### PR DESCRIPTION
## Summary
The CLI entry script (license-checker-rseidelsohn.js) still called `args.parse()`, but that function was renamed to `getNormalizedArguments()` in refactoring commit 80cbe9d3d4e1cf7f528cd9a3a67d2a976df0e393. This caused the binary to fail at runtime.

## Background / Context
After the refactor, invoking the tool (e.g. `npx license-checker-rseidelsohn`) resulted in a TypeError because `parse` is no longer exported. Execution stopped before any license output was produced.

## Change Details
Replaced the outdated `args.parse()` call with `args.getNormalizedArguments()`. No other logic changes.
