### PR TITLE
fix(asPlainVertical): show custom license titles instead of null

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -880,28 +880,7 @@ const asPlainVertical = (sorted) =>
 		.map(([moduleName, moduleData]) => {
 			let licenseText = helpers.getModuleNameForLicenseTextHeader(moduleName);
 
-			if (Array.isArray(moduleData.licenses) && moduleData.licenses.length > 0) {
-				licenseText += moduleData.licenses.map((moduleLicense) => {
-					/*istanbul ignore else*/
-					if (typeof moduleLicense === 'object') {
-						/*istanbul ignore next*/
-						return moduleLicense.type || moduleLicense.name;
-					}
-
-					/*istanbul ignore next*/
-					if (typeof moduleLicense === 'string') {
-						return moduleLicense;
-					}
-				});
-			} else if (
-				typeof moduleData.licenses === 'object' &&
-				(moduleData.licenses.type || moduleData.licenses.name)
-			) {
-				licenseText += getLicenseTitle(moduleData.licenses.type || moduleData.licenses.name);
-			} else if (typeof moduleData.licenses === 'string') {
-				licenseText += getLicenseTitle(moduleData.licenses);
-			}
-
+			licenseText += moduleData.licenses;
 			licenseText += '\n';
 
 			if (Array.isArray(moduleData.licenseFile) && moduleData.licenseFile.length > 0) {

--- a/tests/test.js
+++ b/tests/test.js
@@ -926,6 +926,45 @@ BSD-3-Clause
         });
     });
 
+    describe('should export custom license type correctly', function () {
+        let output;
+
+        before(function (done) {
+            this.timeout(5000);
+
+            checker.init(
+                {
+                    start: path.join(__dirname, './fixtures/custom-license-file'),
+                },
+                function (err, sorted) {
+                    output = sorted;
+                    done();
+                },
+            );
+        });
+
+        it('as csv', function () {
+            const data = checker.asCSV(output);
+            assert.equal(data, '"module name","license","repository"\n' +
+                               '"custom-license@0.0.0","Custom: MY-LICENSE.md",""');
+        });
+
+        it('as markdown', function () {
+            const data = checker.asMarkDown(output);
+            assert.equal(data, '- [custom-license@0.0.0](undefined) - Custom: MY-LICENSE.md');
+        });
+
+        it('as summary', function () {
+            const data = checker.asSummary(output);
+            assert.equal(data, '└─ Custom: MY-LICENSE.md: 1\n');
+        });
+
+        it('as Angular CLI like plain vertical format', function () {
+            const data = checker.asPlainVertical(output);
+            assert.equal(data, 'custom-license 0.0.0\nCustom: MY-LICENSE.md\n');
+        });
+    });
+
     describe('json parsing', function () {
         it('should parse json successfully (File exists + was json)', function () {
             const path = './tests/config/custom_format_correct.json';


### PR DESCRIPTION
## Summary
Fixes an issue where custom license identifiers (e.g. `Custom: MY-LICENSE.md`) were rendered as `null` in the `--plainVertical` output format.

## Background / Context
When generating the Angular CLI–style plain vertical output, the formatter attempted to re-derive a license title from `moduleData.licenses`. Earlier in the collection pipeline, license data had already been normalized to a plain string. Re-processing that string with `getLicenseTitle()` caused custom licenses to resolve to `null`.

## Root Cause
`asPlainVertical()` assumed `moduleData.licenses` could still be an object/array and redundantly invoked logic that expects a structured license object. For custom license strings like `Custom: MY-LICENSE.md`, this second pass yielded `null`.

## Change Details
- Removed the redundant branching and transformation of `moduleData.licenses` in `asPlainVertical`.
- Now the function outputs the already-normalized `moduleData.licenses` value directly.
- Added/retained a regression test ensuring a custom license is emitted correctly in the plain vertical format.

### Before (Broken)
```
custom-license 0.0.0
null
```

### After (Fixed)
```
custom-license 0.0.0
Custom: MY-LICENSE.md
```
