### PR TITLE
Add `depth` and `isDevDependency` CSV columns / module info; recurse direct dependencies

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -165,6 +165,14 @@ export interface ModuleInfo {
      * Path of NOTICE file
      */
     noticeFile?: string | undefined;
+    /**
+     * Depth in the dependency tree
+     */
+    depth?: number | undefined;
+    /**
+     * Is it a dev dependency?
+     */
+    isDevDependency?: boolean | undefined;
 }
 
 export interface ModuleInfos {

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,11 @@ debugLog.log = console.log.bind(console);
 // second iteration, it collects the data from all direct dependencies, then it collects their dependencies and so on.
 const recursivelyCollectAllDependencies = (options) => {
     const { color: colorize, deps: currentExtendedPackageJson, unknown } = options;
-    const moduleInfo = { ...INITIAL_MODULE_INFO };
+    const moduleInfo = {
+        ...INITIAL_MODULE_INFO,
+        depth: options.currentRecursionDepth,
+        isDevDependency: options.isDevDependency,
+    };
     const currentPackageNameAndVersion = `${currentExtendedPackageJson.name}@${currentExtendedPackageJson.version}`;
 
     let { data } = options;
@@ -317,12 +321,14 @@ const recursivelyCollectAllDependencies = (options) => {
     });
 
     /*istanbul ignore else*/
-    if (currentExtendedPackageJson.dependencies) {
-        Object.keys(currentExtendedPackageJson.dependencies).forEach((dependencyName) => {
+    if (currentExtendedPackageJson._dependencies && currentExtendedPackageJson.dependencies) {
+        Object.keys(currentExtendedPackageJson._dependencies).forEach((dependencyName) => {
             const childDependency =
                 options.currentRecursionDepth > options._args.direct
                     ? {}
-                    : currentExtendedPackageJson.dependencies[dependencyName];
+                    : currentExtendedPackageJson.dependencies[dependencyName] ??
+                      currentExtendedPackageJson.peerDependencies[dependencyName] ??
+                      {};
             const dependencyId = `${childDependency.name}@${childDependency.version}`;
 
             if (data[dependencyId]) {
@@ -342,6 +348,8 @@ const recursivelyCollectAllDependencies = (options) => {
                 unknown,
                 currentRecursionDepth: options.currentRecursionDepth + 1,
                 clarifications: options.clarifications,
+                isDevDependency:
+                    options.isDevDependency || !!currentExtendedPackageJson.devDependencies?.[dependencyName],
             });
         });
     }


### PR DESCRIPTION
This adds the option to include the columns `depth` and `isDevDependency` when outputting CSV files. This allows you to easily filter the data later - e.g. you can produce a single file containing all dev dependencies, and dependencies from any depth, and then filter the data later to only show the direct dependencies (`depth = 1`) or Prod dependencies `isDevDependency = false`.

I found that the tool was iterating `dependencies`, which seems to be a flat array of all dependencies. I changed it to iterate `_dependencies`, which only includes the direct dependencies. This gives proper values of `depth` and `isDevDependency` based on whether the parent was a dev dependency. I haven't fully tested the consequences of this (the unit tests do not run in NodeJS v24, because it tries to load CommonJS modules as ECMAScript modules).

There might be a better name for these new columns.

I based this off tag `v4.4.2`, because `master` had an issue (the bin does not work because it tries to call the function `parse()`, but it was renamed to `parseArgs()`), so I didn't know what the current state of development was.