### PR TITLE
Security: Path Traversal vulnerability in --files option

### DIFF
--- a/lib/licenseCheckerHelpers.js
+++ b/lib/licenseCheckerHelpers.js
@@ -5,6 +5,10 @@ import path from 'node:path';
 
 import * as licenseChecker from './index.js';
 
+const sanitizeModuleName = function sanitizeModuleName(name) {
+    return name.replace(/[\\/]/g, '_');
+};
+
 const shouldColorizeOutput = function shouldColorizeOutput(args) {
     return args.color && !args.out && !args.files && !(args.csv || args.json || args.markdown || args.plainVertical);
 };
@@ -44,7 +48,8 @@ const getFormattedOutput = function getFormattedOutput(modulesWithVersions, args
 
     if (args.files) {
         Object.keys(jsonCopy).forEach((moduleName) => {
-            const outPath = path.join(args.files, `${moduleName}-LICENSE.txt`);
+            const sanitizedName = sanitizeModuleName(moduleName);
+            const outPath = path.join(args.files, `${sanitizedName}-LICENSE.txt`);
             const originalLicenseFile = jsonCopy[moduleName].licenseFile;
 
             if (originalLicenseFile && fs.existsSync(originalLicenseFile)) {


### PR DESCRIPTION
## Summary

Security: Path Traversal vulnerability in --files option

## Problem

**Severity**: `High` | **File**: `lib/licenseCheckerHelpers.js:L102`

The module name from package.json is directly used in file paths without sanitization. A malicious package name containing path traversal sequences (e.g., '../../../etc/passwd') could allow writing files to arbitrary locations on the filesystem.

## Solution

Add validation and sanitization for module names before using them in file paths. Use a whitelist approach or sanitize the module name to remove any path traversal characters.

## Changes

- `lib/licenseCheckerHelpers.js` (modified)