### PR TITLE
fix: use package version for CLI output

### DIFF
--- a/lib/exitProcessOrWarnIfNeeded.js
+++ b/lib/exitProcessOrWarnIfNeeded.js
@@ -1,6 +1,7 @@
+import packageJson from '../package.json' with { type: 'json' };
 import { usageMessage } from './usageMessage.js';
 
-const version = '4.4.2';
+const version = packageJson.version;
 
 export const exitProcessOrWarnIfNeeded = ({ unknownArgs, parsedArgs }) => {
 	if (unknownArgs.length) {

--- a/tests/bin-test.js
+++ b/tests/bin-test.js
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { text } from 'node:stream/consumers';
+import packageJson from '../package.json' with { type: 'json' };
 
 const __dirname = path.dirname(new URL(import.meta.url).pathname);
 const binPath = path.join(__dirname, '../bin/license-checker-rseidelsohn');
@@ -84,6 +85,14 @@ describe('bin/license-checker-rseidelsohn', () => {
 		assert.equal(code, 0);
 		assert.ok(stdout.includes(fixturePackageName));
 		assert.ok(stdout.includes(fixtureLicense));
+	});
+
+	it('should output the package version from the CLI', async () => {
+		const { code, stderr, stdout } = await runBin(['--version']);
+
+		assert.equal(code, 1);
+		assert.equal(stdout, '');
+		assert.equal(stderr.trim(), packageJson.version);
 	});
 
 	it('should exit 1 without stdout if --failOn MIT finds a matching license', async () => {


### PR DESCRIPTION
Fixes #144

This removes the hard-coded `4.4.2` in `lib/exitProcessOrWarnIfNeeded.js`. The CLI now reads `package.json.version`, so `--version`, `--help`, and unknown-option output stay in sync with the package metadata.

Validation:
- `node bin/license-checker-rseidelsohn.js --version` -> `5.0.1`
- `npm test -- tests/bin-test.js` -> 1 file, 15 tests passed
- `npm test` -> 12 files, 155 tests passed
- `npm run check` -> passed

Note: `npm ci` completed, with engine warnings because local Node is `v24.14.0` and some dependencies request `^24.15.0`. 